### PR TITLE
Fix UUID

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "ExprOptimization"
-uuid = "4bafb4bd-4c51-463f-bd0a-5a4e66f7034f"
+uuid = "0d84ce59-e78b-5c9a-b954-3a5400d7f6ed"
 authors = ["Ritchie Lee <ritchie@ritchielee.net>", "Mykel Kochenderfer <mykel@stanford.edu>"]
 version = "0.2.1"
 


### PR DESCRIPTION
The [previous PR](https://github.com/sisl/ExprOptimization.jl/pull/20) added the `Project.toml` with an UUID that is generated by `] generate ExprOptimization` on my local machine. 

This works fine if someone does `] add https://github.com/sisl/ExprOptimization.jl`

However, this is not the same UUID that the offical regiestry currently used for this package (`0d84ce59-e78b-5c9a-b954-3a5400d7f6ed`). 

This means `] add ExprOptimization#master` thorws error.

```
ERROR: UUID `4bafb4bd-4c51-463f-bd0a-5a4e66f7034f` given by project file `/tmp/jl_Qp3CnN/Project.toml` 
does not match given UUID `0d84ce59-e78b-5c9a-b954-3a5400d7f6ed`
```

Hopefully by using the existinng one this issue can be fixed.